### PR TITLE
Add router base directory

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,6 +5,11 @@ export default {
   // Target: https://go.nuxtjs.dev/config-target
   target: 'static',
 
+  // Router: https://nuxtjs.org/deployments/github-pages/
+  router: {
+    base: '/online-game-guides/'
+  },
+
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
     title: 'online-game-guides',


### PR DESCRIPTION
While we are using default github domain, we need to set a base path for the router.